### PR TITLE
Expose spy words globally for cheatsheet

### DIFF
--- a/cheatsheet.js
+++ b/cheatsheet.js
@@ -1,0 +1,23 @@
+window.addEventListener('DOMContentLoaded', () => {
+  const spyBoard = document.querySelector('.spy-board');
+  if (!spyBoard || !window.opener) return;
+
+  const words = window.opener.words || [];
+  const drinkWord = window.opener.drinkWord || new Set();
+
+  function createCard(word, team) {
+    const card = document.createElement('div');
+    card.className = `card-spy ${team}`;
+    card.setAttribute('data-word', word);
+    card.innerText = word.toUpperCase();
+    if (typeof drinkWord.has === 'function' && drinkWord.has(word)) {
+      card.classList.add('shot');
+    }
+    return card;
+  }
+
+  words.forEach(({ word, team }) => {
+    const card = createCard(word, team);
+    spyBoard.appendChild(card);
+  });
+});

--- a/codename_tvGame/script.js
+++ b/codename_tvGame/script.js
@@ -723,6 +723,10 @@ startButton.addEventListener('click', function () {
 
   displayRemainingCards();
 
+  // expose spy words globally before cheatsheet can be opened
+  window.words = words;
+  window.drinkWord = drinkWord;
+
   //Display the END Turn and Spies Cheat sheet button
 
   btnSpiesCheatSheet.classList.remove('invisible-button');

--- a/script.js
+++ b/script.js
@@ -723,6 +723,10 @@ startButton.addEventListener('click', function () {
 
   displayRemainingCards();
 
+  // expose spy words globally before cheatsheet can be opened
+  window.words = words;
+  window.drinkWord = drinkWord;
+
   //Display the END Turn and Spies Cheat sheet button
 
   btnSpiesCheatSheet.classList.remove('invisible-button');


### PR DESCRIPTION
## Summary
- expose spy words and drink words on the `window` object once the board has been populated
- mirror these changes in the `codename_tvGame` version
- add new helper script `cheatsheet.js` that reads `window.opener.words` and fills the spy board

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68771be1e4cc83208da02a277534762a