### PR TITLE
Enable cheat-sheet data sharing

### DIFF
--- a/codename_tvGame/script.js
+++ b/codename_tvGame/script.js
@@ -691,6 +691,10 @@ startButton.addEventListener('click', function () {
 
   words.sort(() => 0.5 - Math.random());
 
+  // expose the populated arrays for the cheat sheet window
+  window.words = words;
+  window.drinkWord = drinkWord;
+
   //CREATES THE CARDS ON THE BOARD
 
   function createCard(word, team) {

--- a/script.js
+++ b/script.js
@@ -691,6 +691,10 @@ startButton.addEventListener('click', function () {
 
   words.sort(() => 0.5 - Math.random());
 
+  // expose the populated arrays for the cheat sheet window
+  window.words = words;
+  window.drinkWord = drinkWord;
+
   //CREATES THE CARDS ON THE BOARD
 
   function createCard(word, team) {


### PR DESCRIPTION
## Summary
- expose the populated words and drinkWord sets on `window`
- expose these globals in both the desktop and TV versions

## Testing
- `node -c script.js`
- `node -c codename_tvGame/script.js`
- ❌ `npm install jsdom@22 --no-save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68771e9c3acc832093b81d69d604cbba